### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     ".": {
       "import": "./lib/index.mjs",
       "require": "./lib/index.js",
-      "browser": "./lib/index.module.js"
+      "browser": "./lib/index.module.js",
+      "types": "./lib/index.d.ts"
     },
     "./lib/css/styles.css": "./lib/css/styles.css"
   },


### PR DESCRIPTION
Add TypeScript type definitions to `exports` field. This fixes issues with TypeScript when importing package has `"moduleResolution": "nodenext"`

<!--
  Before opening the request, make sure that all the listed conditions are met.

  - Code is up-to-date with the `master` branch.
  - `yarn test (npm run test)` passes with this change.
  - The new commits follow conventions explained in [CONTRIBUTING.md](https://github.com/Wondermarin/react-color-palette/blob/master/.github/CONTRIBUTING.md)

  If your PR adds new functionality, you should also change the `demo`!
-->

### Description of Change

<!--
  A brief description of what you did and why the project needs it.
-->

<!--
  Thank you for helping the project, thanks to you it will live <3
-->
